### PR TITLE
Make Thermal Foundation optional

### DIFF
--- a/src/main/java/exter/foundry/Foundry.java
+++ b/src/main/java/exter/foundry/Foundry.java
@@ -56,7 +56,7 @@ import net.minecraftforge.fml.relauncher.Side;
         modid = Foundry.MODID,
         name = Foundry.MODNAME,
         version = "@VERSION_INJECT@",
-        dependencies = "after:jei@[4.12,);required-after:ceramics;required-after:thermalfoundation;after:mekanism;after:enderio;after:botania;after:techreborn;"
+        dependencies = "after:jei@[4.12,);required-after:ceramics;required-after:cofhcore;after:thermalfoundation;after:mekanism;after:enderio;after:botania;after:techreborn;"
 )
 public class Foundry
 {

--- a/src/main/java/exter/foundry/api/FoundryUtils.java
+++ b/src/main/java/exter/foundry/api/FoundryUtils.java
@@ -13,6 +13,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -100,156 +101,140 @@ public class FoundryUtils
         final String armor = "Equipment.Armor." + StringHelper.titleCase(name);
         OreMatcher stick = new OreMatcher("stickWood", 2);
 
-        if (!TFProps.disableAllArmor)
-        {
-            Item helm = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "armor.helmet_" + name));
-            if (helm != null && cfg.get(armor, "Helmet", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(helm),
-                        new FluidStack(fluid, FoundryAPI.getAmountHelm()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(helm),
-                        new FluidStack(fluid, FoundryAPI.getAmountHelm()), SubItem.HELMET.getItem(), false, null);
-            }
+        if (Loader.isModLoaded("thermalfoundation")) {
+            if (!TFProps.disableAllArmor) {
+                Item helm = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "armor.helmet_" + name));
+                if (helm != null && cfg.get(armor, "Helmet", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(helm),
+                            new FluidStack(fluid, FoundryAPI.getAmountHelm()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(helm),
+                            new FluidStack(fluid, FoundryAPI.getAmountHelm()), SubItem.HELMET.getItem(), false, null);
+                }
 
-            Item chest = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "armor.plate_" + name));
-            if (chest != null && cfg.get(armor, "Chestplate", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(chest),
-                        new FluidStack(fluid, FoundryAPI.getAmountChest()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(chest),
-                        new FluidStack(fluid, FoundryAPI.getAmountChest()), SubItem.CHESTPLATE.getItem(), false, null);
-            }
+                Item chest = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "armor.plate_" + name));
+                if (chest != null && cfg.get(armor, "Chestplate", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(chest),
+                            new FluidStack(fluid, FoundryAPI.getAmountChest()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(chest),
+                            new FluidStack(fluid, FoundryAPI.getAmountChest()), SubItem.CHESTPLATE.getItem(), false, null);
+                }
 
-            Item legs = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "armor.legs_" + name));
-            if (legs != null && cfg.get(armor, "Leggings", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(legs),
-                        new FluidStack(fluid, FoundryAPI.getAmountLegs()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(legs),
-                        new FluidStack(fluid, FoundryAPI.getAmountLegs()), SubItem.LEGGINGS.getItem(), false, null);
-            }
+                Item legs = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "armor.legs_" + name));
+                if (legs != null && cfg.get(armor, "Leggings", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(legs),
+                            new FluidStack(fluid, FoundryAPI.getAmountLegs()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(legs),
+                            new FluidStack(fluid, FoundryAPI.getAmountLegs()), SubItem.LEGGINGS.getItem(), false, null);
+                }
 
-            Item boots = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "armor.boots_" + name));
-            if (boots != null && cfg.get(armor, "Boots", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(boots),
-                        new FluidStack(fluid, FoundryAPI.getAmountBoots()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(boots),
-                        new FluidStack(fluid, FoundryAPI.getAmountBoots()), SubItem.BOOTS.getItem(), false, null);
-            }
-        }
-
-        if (!TFProps.disableAllTools)
-        {
-            if (!TFProps.disableAllShears)
-            {
-                Item shears = ForgeRegistries.ITEMS
-                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.shears_" + name));
-                if (shears != null && cfg.get(tools, "Shears", true).getBoolean(true))
-                {
-                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(shears),
-                            new FluidStack(fluid, FoundryAPI.getAmountShears()));
-                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(shears),
-                            new FluidStack(fluid, FoundryAPI.getAmountShears()), SubItem.SHEARS.getItem(), false, null);
+                Item boots = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "armor.boots_" + name));
+                if (boots != null && cfg.get(armor, "Boots", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(boots),
+                            new FluidStack(fluid, FoundryAPI.getAmountBoots()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(boots),
+                            new FluidStack(fluid, FoundryAPI.getAmountBoots()), SubItem.BOOTS.getItem(), false, null);
                 }
             }
 
-            if (!TFProps.disableAllShields)
-            {
-                Item shield = ForgeRegistries.ITEMS
-                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.shield_" + name));
-                if (shield != null && cfg.get(tools, "Shield", true).getBoolean(true))
-                {
-                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(shield),
+            if (!TFProps.disableAllTools) {
+                if (!TFProps.disableAllShears) {
+                    Item shears = ForgeRegistries.ITEMS
+                            .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.shears_" + name));
+                    if (shears != null && cfg.get(tools, "Shears", true).getBoolean(true)) {
+                        FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(shears),
+                                new FluidStack(fluid, FoundryAPI.getAmountShears()));
+                        FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(shears),
+                                new FluidStack(fluid, FoundryAPI.getAmountShears()), SubItem.SHEARS.getItem(), false, null);
+                    }
+                }
+
+                if (!TFProps.disableAllShields) {
+                    Item shield = ForgeRegistries.ITEMS
+                            .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.shield_" + name));
+                    if (shield != null && cfg.get(tools, "Shield", true).getBoolean(true)) {
+                        FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(shield),
+                                new FluidStack(fluid, FoundryAPI.getAmountSword()));
+                        FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(shield),
+                                new FluidStack(fluid, FoundryAPI.getAmountSword()), SubItem.SHIELD.getItem(), true, null);
+                    }
+                }
+
+                Item pickaxe = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.pickaxe_" + name));
+                if (pickaxe != null && cfg.get(tools, "Pickaxe", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(pickaxe),
+                            new FluidStack(fluid, FoundryAPI.getAmountPickaxe()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(pickaxe),
+                            new FluidStack(fluid, FoundryAPI.getAmountPickaxe()), SubItem.PICKAXE.getItem(), false, stick);
+                }
+
+                Item axe = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.axe_" + name));
+                if (axe != null && cfg.get(tools, "Axe", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(axe),
+                            new FluidStack(fluid, FoundryAPI.getAmountAxe()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(axe),
+                            new FluidStack(fluid, FoundryAPI.getAmountAxe()), SubItem.AXE.getItem(), false, stick);
+                }
+                Item shovel = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.shovel_" + name));
+                if (shovel != null && cfg.get(tools, "Shovel", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(shovel),
+                            new FluidStack(fluid, FoundryAPI.getAmountShovel()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(shovel),
+                            new FluidStack(fluid, FoundryAPI.getAmountShovel()), SubItem.SHOVEL.getItem(), false, stick);
+                }
+
+                Item hoe = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.hoe_" + name));
+                if (hoe != null && cfg.get(tools, "Hoe", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(hoe),
+                            new FluidStack(fluid, FoundryAPI.getAmountHoe()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(hoe),
+                            new FluidStack(fluid, FoundryAPI.getAmountHoe()), SubItem.HOE.getItem(), false, stick);
+                }
+                Item sword = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.sword_" + name));
+                if (sword != null && cfg.get(tools, "Sword", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(sword),
                             new FluidStack(fluid, FoundryAPI.getAmountSword()));
-                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(shield),
-                            new FluidStack(fluid, FoundryAPI.getAmountSword()), SubItem.SHIELD.getItem(), true, null);
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(sword),
+                            new FluidStack(fluid, FoundryAPI.getAmountSword()), SubItem.SWORD.getItem(), false,
+                            new OreMatcher("stickWood"));
                 }
-            }
 
-            Item pickaxe = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.pickaxe_" + name));
-            if (pickaxe != null && cfg.get(tools, "Pickaxe", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(pickaxe),
-                        new FluidStack(fluid, FoundryAPI.getAmountPickaxe()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(pickaxe),
-                        new FluidStack(fluid, FoundryAPI.getAmountPickaxe()), SubItem.PICKAXE.getItem(), false, stick);
-            }
+                Item sickle = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.sickle_" + name));
+                if (sickle != null && cfg.get(tools, "Sickle", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(sickle),
+                            new FluidStack(fluid, FoundryAPI.getAmountSickle()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(sickle),
+                            new FluidStack(fluid, FoundryAPI.getAmountSickle()), SubItem.SICKLE.getItem(), false,
+                            new OreMatcher("stickWood"));
+                }
 
-            Item axe = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.axe_" + name));
-            if (axe != null && cfg.get(tools, "Axe", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(axe),
-                        new FluidStack(fluid, FoundryAPI.getAmountAxe()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(axe),
-                        new FluidStack(fluid, FoundryAPI.getAmountAxe()), SubItem.AXE.getItem(), false, stick);
-            }
-            Item shovel = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.shovel_" + name));
-            if (shovel != null && cfg.get(tools, "Shovel", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(shovel),
-                        new FluidStack(fluid, FoundryAPI.getAmountShovel()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(shovel),
-                        new FluidStack(fluid, FoundryAPI.getAmountShovel()), SubItem.SHOVEL.getItem(), false, stick);
-            }
+                Item hammer = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.hammer_" + name));
+                if (hammer != null && cfg.get(tools, "Hammer", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(hammer),
+                            new FluidStack(fluid, FoundryAPI.getAmountHammer()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(hammer),
+                            new FluidStack(fluid, FoundryAPI.getAmountHammer()), SubItem.HAMMER.getItem(), false, stick);
+                }
 
-            Item hoe = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.hoe_" + name));
-            if (hoe != null && cfg.get(tools, "Hoe", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(hoe),
-                        new FluidStack(fluid, FoundryAPI.getAmountHoe()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(hoe),
-                        new FluidStack(fluid, FoundryAPI.getAmountHoe()), SubItem.HOE.getItem(), false, stick);
-            }
-            Item sword = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.sword_" + name));
-            if (sword != null && cfg.get(tools, "Sword", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(sword),
-                        new FluidStack(fluid, FoundryAPI.getAmountSword()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(sword),
-                        new FluidStack(fluid, FoundryAPI.getAmountSword()), SubItem.SWORD.getItem(), false,
-                        new OreMatcher("stickWood"));
-            }
-
-            Item sickle = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.sickle_" + name));
-            if (sickle != null && cfg.get(tools, "Sickle", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(sickle),
-                        new FluidStack(fluid, FoundryAPI.getAmountSickle()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(sickle),
-                        new FluidStack(fluid, FoundryAPI.getAmountSickle()), SubItem.SICKLE.getItem(), false,
-                        new OreMatcher("stickWood"));
-            }
-
-            Item hammer = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.hammer_" + name));
-            if (hammer != null && cfg.get(tools, "Hammer", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(hammer),
-                        new FluidStack(fluid, FoundryAPI.getAmountHammer()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(hammer),
-                        new FluidStack(fluid, FoundryAPI.getAmountHammer()), SubItem.HAMMER.getItem(), false, stick);
-            }
-
-            Item excavator = ForgeRegistries.ITEMS
-                    .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.excavator_" + name));
-            if (excavator != null && cfg.get(tools, "Excavator", true).getBoolean(true))
-            {
-                FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(excavator),
-                        new FluidStack(fluid, FoundryAPI.getAmountExcavator()));
-                FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(excavator),
-                        new FluidStack(fluid, FoundryAPI.getAmountExcavator()), SubItem.EXCAVATOR.getItem(), false,
-                        stick);
+                Item excavator = ForgeRegistries.ITEMS
+                        .getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "tool.excavator_" + name));
+                if (excavator != null && cfg.get(tools, "Excavator", true).getBoolean(true)) {
+                    FoundryAPI.MELTING_MANAGER.addRecipe(new ItemStackMatcher(excavator),
+                            new FluidStack(fluid, FoundryAPI.getAmountExcavator()));
+                    FoundryAPI.CASTING_MANAGER.addRecipe(new ItemStackMatcher(excavator),
+                            new FluidStack(fluid, FoundryAPI.getAmountExcavator()), SubItem.EXCAVATOR.getItem(), false,
+                            stick);
+                }
             }
         }
     }

--- a/src/main/java/exter/foundry/block/BlockLiquidMetal.java
+++ b/src/main/java/exter/foundry/block/BlockLiquidMetal.java
@@ -26,6 +26,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.BlockFluidClassic;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -203,7 +204,14 @@ public class BlockLiquidMetal extends BlockFluidClassic
     {
         // Check if block is in contact with water.
         IBlockState nstate = world.getBlockState(npos);
-        if (nstate.getBlock() == TFFluids.blockFluidCryotheum || nstate.getMaterial() == Material.WATER)
+
+        boolean isLiquid = nstate.getMaterial() == Material.WATER;
+
+        if (Loader.isModLoaded("thermalfoundation")) {
+            isLiquid = isLiquid || nstate.getBlock() == TFFluids.blockFluidCryotheum;
+        }
+
+        if (isLiquid)
         {
             world.setBlockState(pos, state);
             world.playSound(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, SoundEvents.BLOCK_LAVA_EXTINGUISH,

--- a/src/main/java/exter/foundry/config/FoundryConfig.java
+++ b/src/main/java/exter/foundry/config/FoundryConfig.java
@@ -11,6 +11,7 @@ import exter.foundry.block.BlockMachine;
 import exter.foundry.tileentity.TileEntityHeatable;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -37,9 +38,15 @@ public class FoundryConfig
     public static boolean metalCasterPower = true;
     public static boolean crtError = true;
 
-    public static String prefModID = ThermalFoundation.MOD_ID;
+    public static String prefModID;
 
     public static boolean castingTableUncrafting = true;
+
+    static {
+        if (Loader.isModLoaded("thermalfoundation")) {
+            prefModID = ThermalFoundation.MOD_ID;
+        }
+    }
 
     static public void load(File file)
     {
@@ -74,7 +81,7 @@ public class FoundryConfig
             hardcore_furnace_keep_ingots.add("ingot" + name);
         }
 
-        prefModID = config.getString("Preferred Mod ID", "recipes", ThermalFoundation.MOD_ID,
+        prefModID = config.getString("Preferred Mod ID", "recipes", prefModID,
                 "The priority MODID for Foundry recipes to try using.");
 
         metalCasterPower = config.getBoolean("Metal Caster Power", "general", true,

--- a/src/main/java/exter/foundry/fluid/FoundryFluids.java
+++ b/src/main/java/exter/foundry/fluid/FoundryFluids.java
@@ -12,6 +12,7 @@ import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemDye;
 import net.minecraftforge.event.RegistryEvent.Register;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.registries.IForgeRegistry;
@@ -86,19 +87,26 @@ public class FoundryFluids
          */
 
         int temp = 1550;
-        BlockFluidInteractive pyrotheum = (BlockFluidInteractive) TFFluids.blockFluidPyrotheum;
-        BlockFluidInteractive mana = (BlockFluidInteractive) TFFluids.blockFluidMana;
         liquid_glass = FoundryFluidRegistry.INSTANCE.registerLiquidGlass(registry, "glass", temp, 12, "glass",
                 0x40FFFFFF, Blocks.GLASS.getDefaultState());
-        pyrotheum.addInteraction(Blocks.SAND, liquid_glass.getBlock());
-        pyrotheum.addInteraction(Blocks.GLASS, liquid_glass.getBlock());
-        pyrotheum.addInteraction(Blocks.SPONGE.getDefaultState().withProperty(BlockSponge.WET, true),
-                Blocks.SPONGE.getDefaultState().withProperty(BlockSponge.WET, false));
-        mana.addInteraction(liquid_glass.getBlock(), Blocks.SAND);
-        mana.addInteraction(Blocks.STAINED_GLASS, Blocks.SAND);
+
+        BlockFluidInteractive pyrotheum = null;
+        BlockFluidInteractive mana = null;
+
+        if (Loader.isModLoaded("thermalfoundation")) {
+            pyrotheum = (BlockFluidInteractive) TFFluids.blockFluidPyrotheum;
+            mana = (BlockFluidInteractive) TFFluids.blockFluidMana;
+
+            pyrotheum.addInteraction(Blocks.SAND, liquid_glass.getBlock());
+            pyrotheum.addInteraction(Blocks.GLASS, liquid_glass.getBlock());
+            pyrotheum.addInteraction(Blocks.SPONGE.getDefaultState().withProperty(BlockSponge.WET, true),
+                    Blocks.SPONGE.getDefaultState().withProperty(BlockSponge.WET, false));
+            mana.addInteraction(liquid_glass.getBlock(), Blocks.SAND);
+            mana.addInteraction(Blocks.STAINED_GLASS, Blocks.SAND);
+        }
+
         IBlockState stained_glass = Blocks.STAINED_GLASS.getDefaultState();
-        for (EnumDyeColor dye : EnumDyeColor.values())
-        {
+        for (EnumDyeColor dye : EnumDyeColor.values()) {
             String name = dye.getName();
 
             int color = ItemDye.DYE_COLORS[dye.getDyeDamage()];
@@ -112,8 +120,11 @@ public class FoundryFluids
             stained_glass = stained_glass.withProperty(BlockColored.COLOR, dye);
             liquid_glass_colored[meta] = FoundryFluidRegistry.INSTANCE.registerLiquidGlass(registry, "glass_" + name,
                     temp, 12, "glass", fluid_color, stained_glass);
-            pyrotheum.addInteraction(stained_glass, liquid_glass_colored[meta].getBlock());
-            mana.addInteraction(liquid_glass_colored[meta].getBlock(), Blocks.SAND);
+
+            if (Loader.isModLoaded("thermalfoundation")) {
+                pyrotheum.addInteraction(stained_glass, liquid_glass_colored[meta].getBlock());
+                mana.addInteraction(liquid_glass_colored[meta].getBlock(), Blocks.SAND);
+            }
         }
     }
 }

--- a/src/main/java/exter/foundry/init/InitAlloyRecipes.java
+++ b/src/main/java/exter/foundry/init/InitAlloyRecipes.java
@@ -90,9 +90,11 @@ public class InitAlloyRecipes
 
         if (FoundryConfig.recipe_steel)
         {
-            InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_steel, FLUID_AMOUNT_INGOT / 4),
+            if (OreDictionary.doesOreNameExist("dustCoal"))
+                InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_steel, FLUID_AMOUNT_INGOT / 4),
                     new FluidStack(FoundryFluids.liquid_iron, FLUID_AMOUNT_INGOT / 4), new OreMatcher("dustCoal"), 2000);
-            InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_steel, FLUID_AMOUNT_INGOT / 4),
+            if (OreDictionary.doesOreNameExist("dustCharcoal"))
+                InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_steel, FLUID_AMOUNT_INGOT / 4),
                     new FluidStack(FoundryFluids.liquid_iron, FLUID_AMOUNT_INGOT / 4), new OreMatcher("dustCharcoal"), 4000);
             if (OreDictionary.doesOreNameExist("dustSmallCoal"))
                 InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_steel, FLUID_AMOUNT_INGOT / 16),

--- a/src/main/java/exter/foundry/init/InitRecipes.java
+++ b/src/main/java/exter/foundry/init/InitRecipes.java
@@ -35,6 +35,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.oredict.OreDictionary;
 
 public class InitRecipes
@@ -214,16 +215,19 @@ public class InitRecipes
         FoundryUtils.registerBasicMeltingRecipes("Aluminum", FoundryFluidRegistry.INSTANCE.getFluid("aluminium"));
         // FoundryUtils.registerBasicMeltingRecipes("Constantan", FoundryFluidRegistry.INSTANCE.getFluid("constantan"));
 
-        MeltingRecipeManager.INSTANCE.addRecipe(new OreMatcher("dustRedstone"),
-                new FluidStack(TFFluids.fluidRedstone, 100));
-        MeltingRecipeManager.INSTANCE.addRecipe(new OreMatcher("blockRedstone"),
-                new FluidStack(TFFluids.fluidRedstone, 900));
-        MeltingRecipeManager.INSTANCE.addRecipe(new OreMatcher("dustGlowstone"),
-                new FluidStack(TFFluids.fluidGlowstone, 250), TFFluids.fluidGlowstone.getTemperature(), 90);
-        MeltingRecipeManager.INSTANCE.addRecipe(new OreMatcher("glowstone"),
-                new FluidStack(TFFluids.fluidGlowstone, 1000), TFFluids.fluidGlowstone.getTemperature(), 90);
-        MeltingRecipeManager.INSTANCE.addRecipe(new ItemStackMatcher(Items.ENDER_PEARL),
-                new FluidStack(TFFluids.fluidEnder, 250), TFFluids.fluidEnder.getTemperature(), 75);
+        if (Loader.isModLoaded("thermalfoundation")) {
+            MeltingRecipeManager.INSTANCE.addRecipe(new OreMatcher("dustRedstone"),
+                    new FluidStack(TFFluids.fluidRedstone, 100));
+            MeltingRecipeManager.INSTANCE.addRecipe(new OreMatcher("blockRedstone"),
+                    new FluidStack(TFFluids.fluidRedstone, 900));
+            MeltingRecipeManager.INSTANCE.addRecipe(new OreMatcher("dustGlowstone"),
+                    new FluidStack(TFFluids.fluidGlowstone, 250), TFFluids.fluidGlowstone.getTemperature(), 90);
+            MeltingRecipeManager.INSTANCE.addRecipe(new OreMatcher("glowstone"),
+                    new FluidStack(TFFluids.fluidGlowstone, 1000), TFFluids.fluidGlowstone.getTemperature(), 90);
+            MeltingRecipeManager.INSTANCE.addRecipe(new ItemStackMatcher(Items.ENDER_PEARL),
+                    new FluidStack(TFFluids.fluidEnder, 250), TFFluids.fluidEnder.getTemperature(), 75);
+        }
+
         MeltingRecipeManager.INSTANCE.addRecipe(new ItemStackMatcher(Blocks.ICE),
                 new FluidStack(FluidRegistry.WATER, 1000), 350, 200);
         MeltingRecipeManager.INSTANCE.addRecipe(new ItemStackMatcher(Blocks.PACKED_ICE),
@@ -282,18 +286,20 @@ public class InitRecipes
         addDefaultCasting(FoundryFluidRegistry.INSTANCE.getFluid("aluminium"), "Aluminum");
         addDefaultCasting(FoundryFluidRegistry.INSTANCE.getFluid("constantan"), "Constantan");
 
-        AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_lumium, FLUID_AMOUNT_INGOT),
-                new FluidStack(TFFluids.fluidGlowstone, 250),
-                new FluidStack(FoundryFluids.liquid_tin, FLUID_AMOUNT_INGOT / 4 * 3),
-                new FluidStack(FoundryFluids.liquid_silver, FLUID_AMOUNT_INGOT / 4));
-        AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_signalum, FLUID_AMOUNT_INGOT),
-                new FluidStack(TFFluids.fluidRedstone, 250),
-                new FluidStack(FoundryFluids.liquid_copper, FLUID_AMOUNT_INGOT / 4 * 3),
-                new FluidStack(FoundryFluids.liquid_silver, FLUID_AMOUNT_INGOT / 4));
-        AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_enderium, FLUID_AMOUNT_INGOT),
-                new FluidStack(TFFluids.fluidEnder, 250),
-                new FluidStack(FoundryFluids.liquid_lead, FLUID_AMOUNT_INGOT / 4 * 3),
-                new FluidStack(FoundryFluids.liquid_platinum, FLUID_AMOUNT_INGOT / 4));
+        if (Loader.isModLoaded("thermalfoundation")) {
+            AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_lumium, FLUID_AMOUNT_INGOT),
+                    new FluidStack(TFFluids.fluidGlowstone, 250),
+                    new FluidStack(FoundryFluids.liquid_tin, FLUID_AMOUNT_INGOT / 4 * 3),
+                    new FluidStack(FoundryFluids.liquid_silver, FLUID_AMOUNT_INGOT / 4));
+            AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_signalum, FLUID_AMOUNT_INGOT),
+                    new FluidStack(TFFluids.fluidRedstone, 250),
+                    new FluidStack(FoundryFluids.liquid_copper, FLUID_AMOUNT_INGOT / 4 * 3),
+                    new FluidStack(FoundryFluids.liquid_silver, FLUID_AMOUNT_INGOT / 4));
+            AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(FoundryFluids.liquid_enderium, FLUID_AMOUNT_INGOT),
+                    new FluidStack(TFFluids.fluidEnder, 250),
+                    new FluidStack(FoundryFluids.liquid_lead, FLUID_AMOUNT_INGOT / 4 * 3),
+                    new FluidStack(FoundryFluids.liquid_platinum, FLUID_AMOUNT_INGOT / 4));
+        }
 
         if (FoundryConfig.recipe_alumina_melts_to_aluminium)
         {
@@ -308,14 +314,16 @@ public class InitRecipes
         }
         else
         {
-            InfuserRecipeManager.INSTANCE.addRecipe(
-                    new FluidStack(FoundryFluids.liquid_aluminium, FLUID_AMOUNT_INGOT * 2),
-                    new FluidStack(FoundryFluids.liquid_alumina, FLUID_AMOUNT_INGOT * 2), new OreMatcher("dustCoal"),
-                    2400);
-            InfuserRecipeManager.INSTANCE.addRecipe(
-                    new FluidStack(FoundryFluids.liquid_aluminium, FLUID_AMOUNT_INGOT * 2),
-                    new FluidStack(FoundryFluids.liquid_alumina, FLUID_AMOUNT_INGOT * 2),
-                    new OreMatcher("dustCharcoal"), 2400);
+            if (OreDictionary.doesOreNameExist("dustCoal"))
+                InfuserRecipeManager.INSTANCE.addRecipe(
+                        new FluidStack(FoundryFluids.liquid_aluminium, FLUID_AMOUNT_INGOT * 2),
+                        new FluidStack(FoundryFluids.liquid_alumina, FLUID_AMOUNT_INGOT * 2), new OreMatcher("dustCoal"),
+                        2400);
+            if (OreDictionary.doesOreNameExist("dustCharcoal"))
+                InfuserRecipeManager.INSTANCE.addRecipe(
+                        new FluidStack(FoundryFluids.liquid_aluminium, FLUID_AMOUNT_INGOT * 2),
+                        new FluidStack(FoundryFluids.liquid_alumina, FLUID_AMOUNT_INGOT * 2),
+                        new OreMatcher("dustCharcoal"), 2400);
             if (OreDictionary.doesOreNameExist("dustSmallCoal"))
                 InfuserRecipeManager.INSTANCE.addRecipe(
                         new FluidStack(FoundryFluids.liquid_aluminium, FLUID_AMOUNT_INGOT / 2),
@@ -353,7 +361,10 @@ public class InitRecipes
         BurnerHeaterFuelManager.INSTANCE.addFuel(new ItemStackMatcher(Items.BLAZE_ROD), 2000, 220000);
 
         FluidHeaterFuelManager.INSTANCE.addFuel(FluidRegistry.LAVA);
-        FluidHeaterFuelManager.INSTANCE.addFuel(TFFluids.fluidPyrotheum);
+
+        if (Loader.isModLoaded("thermalfoundation")) {
+            FluidHeaterFuelManager.INSTANCE.addFuel(TFFluids.fluidPyrotheum);
+        }
     }
 
     static ItemStack mold_ingot = ItemMold.SubItem.INGOT.getItem();

--- a/src/main/java/exter/foundry/init/InitToolRecipes.java
+++ b/src/main/java/exter/foundry/init/InitToolRecipes.java
@@ -13,6 +13,7 @@ import exter.foundry.util.MiscUtil;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.common.Loader;
 
 public class InitToolRecipes
 {
@@ -127,12 +128,13 @@ public class InitToolRecipes
         //                new ItemStack(ForgeRegistries.ITEMS.getValue(new ResourceLocation(ThermalFoundation.MOD_ID, "???"))),
         //                FoundryFluids.liquid_gold, 6, ItemMold.SubItem.BOOTS);
 
-        Configuration cfg = ThermalFoundation.CONFIG.getConfiguration();
-        for (String name : ImmutableList.of("copper", "tin", "silver", "lead", "aluminum", "nickel", "platinum",
-                "steel", "electrum", "invar", "bronze", "constantan", "iron", "gold"))
-        {
-            FoundryUtils.tryAddToolArmorRecipes(cfg, name,
-                    FoundryFluidRegistry.INSTANCE.getFluid(name.equals("aluminum") ? "aluminium" : name));
+        if (Loader.isModLoaded("thermalfoundation")) {
+            Configuration cfg = ThermalFoundation.CONFIG.getConfiguration();
+            for (String name : ImmutableList.of("copper", "tin", "silver", "lead", "aluminum", "nickel", "platinum",
+                    "steel", "electrum", "invar", "bronze", "constantan", "iron", "gold")) {
+                FoundryUtils.tryAddToolArmorRecipes(cfg, name,
+                        FoundryFluidRegistry.INSTANCE.getFluid(name.equals("aluminum") ? "aluminium" : name));
+            }
         }
     }
 }

--- a/src/main/java/exter/foundry/integration/ModIntegrationEnderIO.java
+++ b/src/main/java/exter/foundry/integration/ModIntegrationEnderIO.java
@@ -127,29 +127,30 @@ public class ModIntegrationEnderIO implements IModIntegration
         }
         ItemStack silicon = getItemStack("item_material", 5);
 
-        Fluid liquid_redstone = TFFluids.fluidRedstone;
-        Fluid liquid_enderpearl = TFFluids.fluidEnder;
-        Fluid liquid_glowstone = TFFluids.fluidGlowstone;
+        if (Loader.isModLoaded("thermalfoundation")) {
+            Fluid liquid_redstone = TFFluids.fluidRedstone;
+            Fluid liquid_enderpearl = TFFluids.fluidEnder;
+            Fluid liquid_glowstone = TFFluids.fluidGlowstone;
 
-        if (silicon != null)
-        {
-            InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_redstone_alloy, FLUID_AMOUNT_INGOT),
-                    new FluidStack(liquid_redstone, 100), new ItemStackMatcher(silicon), 12000);
 
-            InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_electrical_steel, FLUID_AMOUNT_INGOT),
-                    new FluidStack(FoundryFluids.liquid_steel, FLUID_AMOUNT_INGOT), new ItemStackMatcher(silicon), 12000);
+            if (silicon != null) {
+                InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_redstone_alloy, FLUID_AMOUNT_INGOT),
+                        new FluidStack(liquid_redstone, 100), new ItemStackMatcher(silicon), 12000);
+
+                InfuserRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_electrical_steel, FLUID_AMOUNT_INGOT),
+                        new FluidStack(FoundryFluids.liquid_steel, FLUID_AMOUNT_INGOT), new ItemStackMatcher(silicon), 12000);
+            }
+
+            AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_energetic_alloy, FLUID_AMOUNT_INGOT / 2),
+                    new FluidStack[]{new FluidStack(FoundryFluids.liquid_gold, FLUID_AMOUNT_INGOT / 2), new FluidStack(liquid_redstone, 50),
+                            new FluidStack(liquid_glowstone, 125)});
+
+            AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_vibrant_alloy, FLUID_AMOUNT_INGOT / 2), new FluidStack[]{
+                    new FluidStack(liquid_energetic_alloy, FLUID_AMOUNT_INGOT / 2), new FluidStack(liquid_enderpearl, 125)});
+
+            AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_phased_iron, FLUID_AMOUNT_INGOT / 2), new FluidStack[]{
+                    new FluidStack(FoundryFluids.liquid_iron, FLUID_AMOUNT_INGOT / 2), new FluidStack(liquid_enderpearl, 125)});
         }
-
-        AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_energetic_alloy, FLUID_AMOUNT_INGOT / 2),
-                new FluidStack[] { new FluidStack(FoundryFluids.liquid_gold, FLUID_AMOUNT_INGOT / 2), new FluidStack(liquid_redstone, 50),
-                        new FluidStack(liquid_glowstone, 125) });
-
-        AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_vibrant_alloy, FLUID_AMOUNT_INGOT / 2), new FluidStack[] {
-                new FluidStack(liquid_energetic_alloy, FLUID_AMOUNT_INGOT / 2), new FluidStack(liquid_enderpearl, 125) });
-
-        AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_phased_iron, FLUID_AMOUNT_INGOT / 2), new FluidStack[] {
-                new FluidStack(FoundryFluids.liquid_iron, FLUID_AMOUNT_INGOT / 2), new FluidStack(liquid_enderpearl, 125) });
-
         AlloyMixerRecipeManager.INSTANCE.addRecipe(new FluidStack(liquid_dark_steel, FLUID_AMOUNT_INGOT / 4), new FluidStack[] {
                 new FluidStack(FoundryFluids.liquid_steel, FLUID_AMOUNT_INGOT / 4), new FluidStack(FluidRegistry.LAVA, 250), });
 


### PR DESCRIPTION
This PR simply wraps all the Thermal Foundation specific stuff in mod loaded checks. I tested it without Thermal Foundation and everything seems in order.

Now I could go the full mile and pull out everything related to Thermal Foundation into mod integration, but then that would mean all recipes would need to be adapted to only use vanilla materials, which doesn't sound ideal. Adding a bunch of nonsense ores and ingots, just in case there's no mods with these materials available is probably an equally terrible idea. In any case, this is all that's needed to make TF optional for modpack authors.