### PR TITLE
Move to a priority list for mod items

### DIFF
--- a/src/main/java/exter/foundry/config/FoundryConfig.java
+++ b/src/main/java/exter/foundry/config/FoundryConfig.java
@@ -1,8 +1,7 @@
 package exter.foundry.config;
 
 import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import exter.foundry.Foundry;
 import exter.foundry.api.FoundryAPI;
@@ -37,14 +36,10 @@ public class FoundryConfig
     public static boolean metalCasterPower = true;
     public static boolean crtError = true;
 
-    public static String prefModID;
+    // Mirrored default settings for Unidict for maximum compatibility
+    public static List<String> modPriority = Arrays.asList("minecraft", "thermalfoundation", "substratum", "ic2", "mekanism", "immersiveengineering", "techreborn");
 
     public static boolean castingTableUncrafting = true;
-
-    static
-    {
-        prefModID = Loader.isModLoaded("thermalfoundation") ? "thermalfoundation" : "minecraft";
-    }
 
     static public void load(File file)
     {
@@ -79,8 +74,8 @@ public class FoundryConfig
             hardcore_furnace_keep_ingots.add("ingot" + name);
         }
 
-        prefModID = config.getString("Preferred Mod ID", "recipes", prefModID,
-                "The priority MODID for Foundry recipes to try using.");
+        modPriority = Arrays.asList(config.getStringList("Preferred Mod ID Priority", "recipes", modPriority.toArray(new String[modPriority.size()]),
+                "The priority sorted MODIDs for Foundry recipes to try using."));
 
         metalCasterPower = config.getBoolean("Metal Caster Power", "general", true,
                 "If the Metal Caster requires power to operate.");

--- a/src/main/java/exter/foundry/init/InitAlloyRecipes.java
+++ b/src/main/java/exter/foundry/init/InitAlloyRecipes.java
@@ -15,6 +15,8 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import java.util.ArrayList;
+
 import static exter.foundry.api.FoundryAPI.FLUID_AMOUNT_INGOT;
 
 public class InitAlloyRecipes
@@ -22,7 +24,7 @@ public class InitAlloyRecipes
     // Create recipes for all alloy making machines.
     static private void addSimpleAlloy(String output, String input_a, int amount_a, String input_b, int amount_b)
     {
-        ItemStack alloy_ingot = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "ingot" + output,
+        ItemStack alloy_ingot = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "ingot" + output,
                 amount_a + amount_b);
         if (!alloy_ingot.isEmpty())
         {

--- a/src/main/java/exter/foundry/init/InitRecipes.java
+++ b/src/main/java/exter/foundry/init/InitRecipes.java
@@ -351,7 +351,7 @@ public class InitRecipes
         }
 
         // Ingot
-        ItemStack ingot = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "ingot" + name);
+        ItemStack ingot = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "ingot" + name);
         if (!ingot.isEmpty())
         {
             FluidStack fluid_stack = new FluidStack(fluid, FLUID_AMOUNT_INGOT);
@@ -361,7 +361,7 @@ public class InitRecipes
         }
 
         // Block
-        ItemStack block = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "block" + name);
+        ItemStack block = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "block" + name);
         if (!block.isEmpty())
         {
             FluidStack fluid_stack = new FluidStack(fluid, FoundryAPI.getAmountBlock());
@@ -371,7 +371,7 @@ public class InitRecipes
         }
 
         // Slab
-        ItemStack slab = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "slab" + name);
+        ItemStack slab = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "slab" + name);
         if (!slab.isEmpty())
         {
             FluidStack fluid_stack = new FluidStack(fluid, FoundryAPI.getAmountBlock() / 2);
@@ -381,7 +381,7 @@ public class InitRecipes
         }
 
         // Stairs
-        ItemStack stairs = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "stairs" + name);
+        ItemStack stairs = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "stairs" + name);
         if (!stairs.isEmpty())
         {
             FluidStack fluid_stack = new FluidStack(fluid, FoundryAPI.getAmountBlock() * 3 / 4);
@@ -391,7 +391,7 @@ public class InitRecipes
         }
 
         // Gear
-        ItemStack gear = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "gear" + name);
+        ItemStack gear = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "gear" + name);
         if (!gear.isEmpty())
         {
             FluidStack fluid_stack = new FluidStack(fluid, FoundryAPI.getAmountGear());
@@ -399,7 +399,7 @@ public class InitRecipes
         }
 
         // Nugget
-        ItemStack nugget = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "nugget" + name);
+        ItemStack nugget = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "nugget" + name);
         if (!nugget.isEmpty())
         {
             FluidStack fluid_stack = new FluidStack(fluid, FoundryAPI.getAmountNugget());
@@ -408,7 +408,7 @@ public class InitRecipes
         }
 
         // Plate
-        ItemStack plate = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "plate" + name);
+        ItemStack plate = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "plate" + name);
         if (!plate.isEmpty())
         {
             FluidStack fluid_stack = new FluidStack(fluid, FoundryAPI.getAmountPlate());
@@ -419,7 +419,7 @@ public class InitRecipes
         }
 
         // Rod
-        ItemStack rod = MiscUtil.getModItemFromOreDictionary(FoundryConfig.prefModID, "rod" + name);
+        ItemStack rod = MiscUtil.getModItemFromOreDictionary(FoundryConfig.modPriority, "rod" + name);
         if (!rod.isEmpty())
         {
             FluidStack fluid_stack = new FluidStack(fluid, FoundryAPI.getAmountRod());


### PR DESCRIPTION
This could use some extra testing, but basically, Foundry was trying to cast cobalt into Chisel's Cobalt blocks, because I had it set to prefer Immersive Engineering, which doesn't have cobalt. This PR uses a UniDict type strategy instead, where you can pick a priority. 