### PR TITLE
Fix McJtyMods/TheOneProbe#277

### DIFF
--- a/src/main/java/exter/foundry/integration/ModIntegrationTheOneProbe.java
+++ b/src/main/java/exter/foundry/integration/ModIntegrationTheOneProbe.java
@@ -1,6 +1,8 @@
 package exter.foundry.integration;
 
 import exter.foundry.integration.top.CastingTableProvider;
+import exter.foundry.integration.top.ElementFluid;
+import exter.foundry.integration.top.ElementTemperature;
 import exter.foundry.integration.top.MeltingCrucibleProvider;
 import exter.foundry.integration.top.MoldStationProvider;
 import mcjty.theoneprobe.api.ITheOneProbe;
@@ -72,6 +74,8 @@ public class ModIntegrationTheOneProbe implements IModIntegration
             probe.registerProvider(new CastingTableProvider());
             probe.registerProvider(new MoldStationProvider());
             probe.registerProvider(new MeltingCrucibleProvider());
+            ElementFluid.ELEMENT_FLUID = probe.registerElementFactory(ElementFluid::new);
+            ElementTemperature.ELEMENT_TEMPERATURE = probe.registerElementFactory(ElementTemperature::new);
             return null;
         }
     }

--- a/src/main/java/exter/foundry/integration/top/ElementFluid.java
+++ b/src/main/java/exter/foundry/integration/top/ElementFluid.java
@@ -1,7 +1,6 @@
 package exter.foundry.integration.top;
 
 import io.netty.buffer.ByteBuf;
-import mcjty.theoneprobe.TheOneProbe;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.apiimpl.client.ElementProgressRender;
 import mcjty.theoneprobe.apiimpl.client.ElementTextRender;
@@ -13,7 +12,7 @@ import java.awt.*;
 
 public class ElementFluid implements IElement
 {
-    private static int ELEMENT_FLUID = TheOneProbe.theOneProbeImp.registerElementFactory(ElementFluid::new);
+    public static int ELEMENT_FLUID;
     private final String fluidName;
     private final int amount, capacity, color1, color2;
     private final boolean sneaking;

--- a/src/main/java/exter/foundry/integration/top/ElementTemperature.java
+++ b/src/main/java/exter/foundry/integration/top/ElementTemperature.java
@@ -1,7 +1,6 @@
 package exter.foundry.integration.top;
 
 import io.netty.buffer.ByteBuf;
-import mcjty.theoneprobe.TheOneProbe;
 import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.apiimpl.client.ElementProgressRender;
 import mcjty.theoneprobe.apiimpl.client.ElementTextRender;
@@ -11,7 +10,7 @@ import java.awt.*;
 
 public class ElementTemperature implements IElement
 {
-    private static int ELEMENT_TEMPERATURE = TheOneProbe.theOneProbeImp.registerElementFactory(ElementTemperature::new);
+    public static int ELEMENT_TEMPERATURE;
     private final int current, max;
 
     public ElementTemperature(int current, int max)


### PR DESCRIPTION
Currently, our TOP elements are registered in the static initializer of
their own classes. These only ever get ran if the providers' corresponding
AddProbeInfo methods get ran. As a result, if a client joins a multiplayer
game immediately after Minecraft loads (i.e., before doing this in single
player), the game will crash. Fix this by moving the registration to the
GetTheOneProbe.apply method, which also lets us remove a reference to an
internal implementation detail of TOP's API (TheOneProbe.theOneProbeImp).